### PR TITLE
fix: throw error from arbitrum and avoid tx

### DIFF
--- a/src/helpers/propagate/arbitrum.ts
+++ b/src/helpers/propagate/arbitrum.ts
@@ -7,11 +7,6 @@ import {type ExtraPropagateParameters, type InitialSetup} from 'src/utils/types'
 
 // Example at https://github.com/OffchainLabs/arbitrum-tutorials/blob/master/packages/greeter/scripts/exec.js
 export const getPropagateParameters = async ({txSigner, arbProvider, provider}: InitialSetup): Promise<ExtraPropagateParameters> => {
-  let submissionPriceWei;
-  let maxGas;
-  let gasPriceBid;
-  let callValue;
-
   const mainnetSdk = getMainnetSdk(txSigner);
 
   const arbSdk = getArbitrumOneSdk(arbProvider);
@@ -19,7 +14,7 @@ export const getPropagateParameters = async ({txSigner, arbProvider, provider}: 
 
   // Example encoded payload: 0x4ff746f6000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000207465737400000000000000000000000000000000000000000000000000000000
   // length = 200 not including 0x = 100 bytes
-  gasPriceBid = await provider.getGasPrice();
+  const gasPriceBid = await provider.getGasPrice();
 
   const baseFee = await getBaseFee(provider);
   const callData = arbSdk.spokeConnector.interface.encodeFunctionData('processMessage', [
@@ -37,10 +32,10 @@ export const getPropagateParameters = async ({txSigner, arbProvider, provider}: 
   );
   const gasLimitForAutoRedeem = l1ToL2MessageGasParameters.gasLimit.mul(5);
 
-  submissionPriceWei = l1ToL2MessageGasParameters.maxSubmissionFee.mul(5).toString();
+  const submissionPriceWei = l1ToL2MessageGasParameters.maxSubmissionFee.mul(5).toString();
   // Multiply gasLimit by 15 to be successful in auto-redeem
-  maxGas = gasLimitForAutoRedeem.toString();
-  callValue = BigNumber.from(submissionPriceWei).add(gasPriceBid.mul(maxGas)).toString();
+  const maxGas = gasLimitForAutoRedeem.toString();
+  const callValue = BigNumber.from(submissionPriceWei).add(gasPriceBid.mul(maxGas)).toString();
 
   const encodedData = utils.defaultAbiCoder.encode(['uint256', 'uint256', 'uint256'], [submissionPriceWei, maxGas, gasPriceBid]);
 

--- a/src/shared/run-propagate.ts
+++ b/src/shared/run-propagate.ts
@@ -35,10 +35,10 @@ export async function runPropagate(
         return;
       }
 
-      // Encode data for relayer proxy hub
-      const {connectors, encodedData, fees} = await populateParametersForDomains(domains, rootManagerMeta, setup);
-
       try {
+        // Encode data for relayer proxy hub
+        const {connectors, encodedData, fees} = await populateParametersForDomains(domains, rootManagerMeta, setup);
+
         await broadcastMethod({jobContract, workMethod, workArguments: [connectors, fees, encodedData], block});
       } catch (error: unknown) {
         if (error instanceof Error) console.log(`Propagate failed with:`, error.message);


### PR DESCRIPTION
**Description**

Currently, when there is an error while getting the propagate parameters of Arbitrum, the transaction goes out with the wrong data for that domain.
Instead of propagating a root that may fail in Arbitrum, avoid propagating the root at all.
