### PR TITLE
fix: gas limit setting

### DIFF
--- a/src/init-propagate.ts
+++ b/src/init-propagate.ts
@@ -9,7 +9,7 @@ import {type Environment, type InitialSetup} from './utils/types';
 
 // SETUP
 const WORK_FUNCTION = 'propagateKeep3r';
-const GAS_LIMIT = 10_000_000;
+const GAS_LIMIT = 2_000_000;
 const PRIORITY_FEE = 2e9;
 
 (async () => {


### PR DESCRIPTION
**Description**

Reduces `gasLimit` to 2M instead of 10M.
Having a 10M gasLimit forces keepers to transact with a required value of:
0.1ETH at 10gwei
1 ETH at 100gwei

Reducing the gasLimit, now keepers require having a total amount of:
0.2 ETH at 100gwei

run at Dune
```sql
select * from ethereum.transactions 
where to = 0xcdbf9d438670d19d1fb3954abc8a13666b302b28
```

median gas used: 800k
max gas used: 1.3M (at 0x30f59534c69e483047eef8974ee686605e2861339b56bb6e46120c1bbc794d34)

plz remember to increase the gasLimit when adding more chains!